### PR TITLE
clean-title-slide

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,14 @@ You may also use this format with an existing Quarto project or document to down
 quarto install extension davidcarayon/quarto-inrae-extension
 ```
 
+## Title slide with `inrae-revealjs`
+
+The slide number and footer are hidden on the title slide.
+
+The title slide footer can be specified with the following syntax:
+
+```
+  inrae-revealjs:
+    title-slide-attributes:
+      data-footer: "<a rel='license' href='http://creativecommons.org/licenses/by-sa/2.0/'><img alt='Creative Commons License' style='border-width:0' src='https://i.creativecommons.org/l/by-sa/2.0/88x31.png' /><br></a>This work is licensed under a <a rel='license' href='http://creativecommons.org/licenses/by-sa/2.0/'>Creative Commons Attribution-ShareAlike 2.0 Generic License</a>."
+```

--- a/_extensions/inrae/_extension.yml
+++ b/_extensions/inrae/_extension.yml
@@ -34,6 +34,8 @@ contributes:
         data-background-size: 40%
         data-background-position: left
         data-background-opacity: "0.5"
+        data-footer: ""
+      include-after-body: ressources/clean-title-slide.html
       logo: ressources/bloc-etat.png
       footer: "Pied de page"
       transition: fade

--- a/_extensions/inrae/ressources/clean-title-slide.html
+++ b/_extensions/inrae/ressources/clean-title-slide.html
@@ -1,0 +1,49 @@
+<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+
+<script type="text/javascript" charset="utf-8">
+  $(document).ready(function() {
+    // Add `data-footer` on title slide
+    function addCustomFooter() {
+      let titleSlide = $("section#title-slide");
+      let titleSlideFooter = titleSlide.attr('data-footer');
+      let footer = $('div.footer p');
+      let globalFooterText = footer.html();
+
+      if (titleSlide.hasClass('present')) {
+        footer.html(titleSlideFooter);
+      }
+
+      Reveal.on('slidechanged', function(event) {
+        if (event.currentSlide.matches('#title-slide')) {
+          footer.html(titleSlideFooter);
+        } else {
+          footer.html(globalFooterText);
+        }
+      });
+    }
+
+    addCustomFooter();
+
+    // Hide slide number on title slide
+    function removeSlideNumber() {
+      let slideNo = $('div.slide-number');
+      slideNo.addClass('hide');
+
+      Reveal.on('slidechanged', function(event) {
+        if (Reveal.isFirstSlide()) {
+          slideNo.addClass('hide');
+        } else {
+          slideNo.removeClass('hide');
+        }
+      });
+    }
+
+    removeSlideNumber();
+  });
+</script>
+
+<style>
+  .hide {
+    display: none !important;
+  }
+</style>


### PR DESCRIPTION
Hello David,

I made these few changes for one of my projects. Maybe you'll like them and they can be added to the repository.

In practice, I hide the slide number and footer on the title slide. The footer can be specific to the title slide. This is particularly useful for specifying the licence, for example.

Thanks in advance  
Bye